### PR TITLE
trulens-providers-cortex 1.1.0 :snowflake:

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AnacondaRecipes/psubs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Truera, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "trulens-providers-cortex" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trulens_providers_cortex-{{ version }}.tar.gz
+  sha256: 3d586521351f7a710850465e9970372bb5d3fd7c490f35576a9fcbd72993ae1d
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 100
+  skip: true  # [py<39 or py>311 or s390x]
+
+requirements:
+  host:
+    - python
+    - poetry-core
+    - pip
+  run:
+    - python
+    - trulens-core >=1.0.0,<2.0.0
+    - trulens-feedback >=1.0.0,<2.0.0
+    - snowflake-connector-python >=3.11.0,<4.0.0
+    - snowflake-snowpark-python >=1.18.0,<2.0.0
+
+test:
+  imports:
+    - trulens
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://trulens.org/
+  summary: A TruLens extension package adding Snowflake Cortex support for LLM App evaluation.
+  description: |
+    Create credible and powerful LLM apps, faster. TruLens is a software tool that helps you 
+    to objectively measure the quality and effectiveness of your LLM-based applications using feedback functions.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/truera/trulens
+  doc_url: https://www.trulens.org/reference/trulens/providers/cortex/
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,4 +48,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - AddYourGitHubIdHere
+    - psteyer


### PR DESCRIPTION
trulens-providers-cortex 1.1.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5845]
- dev_url:        https://github.com/truera/trulens/tree/trulens-1.1.0
- conda_forge:    None
- pypi:           https://pypi.org/project/trulens-providers-cortex/1.1.0
- pypi inspector: https://inspector.pypi.io/project/trulens-providers-cortex/1.1.0

### Explanation of changes:

- new version number
- building `1.1.0` to keep align with the rest of `trulens` recipes


[PKG-5845]: https://anaconda.atlassian.net/browse/PKG-5845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ